### PR TITLE
switch reveal-override.css to SASS for DRY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 shellinaboxd.screen.pid
+/.sass-cache
+/css/*.css.map

--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ form:
 You can share the URL immediately, and GitHub will host it for you,
 indefinitely, for free.
 
+### Theming
+
+The theme is defined in `css/reveal-override.scss` using
+[Sass](http://sass-lang.com/); if you update this, you will need to
+re-compile into `css/reveal-override.css` via:
+
+    $ sass --sourcemap css
+
+If you are doing continual development on the file, then run this in
+the background to automatically re-compile every time the `.scss` file
+is changed:
+
+    $ sass --watch --sourcemap css
+
+If you are using GitHub Pages, make sure that the latest versions of
+the generated `.css` files are committed and pushed to the remote
+`gh-pages` branch.
 
 ### Running things locally
 

--- a/css/reveal-override.css
+++ b/css/reveal-override.css
@@ -4,44 +4,44 @@
 
 /* Disable background 4px border around images */
 .reveal section img {
-  border: none;
-  background: none;
+    border: none;
+    background: none;
 }
 
 /* Blow image up to full screen size */
 .reveal section img
 {
-  height: auto;
-  width: 100%;
-  max-width: 80%;
-  max-height: 80%;
-  margin: 2%;
+    height: auto;
+    width: 100%;
+    max-width: 80%;
+    max-height: 80%;
+    margin: 2%;
 }
 
 /* Blow iframe up to full screen size */
 .reveal iframe
 {
-  height: 90%;
-  width: 100%;
-  margin: 2%;
+    height: 90%;
+    width: 100%;
+    margin: 2%;
 }
 
 body,
 .reveal {
-  font-family: "Open Sans Condensed", sans-serif;
-  font-weight: normal;
+    font-family: "Open Sans Condensed", sans-serif;
+    font-weight: normal;
 }
 
 .reveal h1 {
-  font-size: 5em;
+    font-size: 5em;
 }
 
 .reveal h2 {
-  font-size: 3em;
+    font-size: 3em;
 }
 
 .reveal h3 {
-  font-size: 1.5em;
+    font-size: 1.5em;
 }
 
 .reveal h1,
@@ -50,45 +50,45 @@ body,
 .reveal h4,
 .reveal h5,
 .reveal h6 {
-  font-family: "Cabin", sans-serif;
-  font-weight: bold;
-  text-transform: uppercase;
-  text-stroke: 1px black;
-  color: white;
-  text-shadow:
-    3px 3px 0 #000,
-    -1px -1px 0 #000,  
-    1px -1px 0 #000,
-    -1px 1px 0 #000,
-    1px 1px 0 #000;
+    font-family: "Cabin", sans-serif;
+    font-weight: bold;
+    text-transform: uppercase;
+    text-stroke: 1px black;
+    color: white;
+    text-shadow:
+        3px 3px 0 #000,
+        -1px -1px 0 #000,
+        1px -1px 0 #000,
+        -1px 1px 0 #000,
+        1px 1px 0 #000;
 }
 
 .reveal .progress span {
-  background-color: black
+    background-color: black
 }
 
 .reveal .controls div.navigate-up,
 .reveal .controls div.navigate-up.enabled
 {
-  border-bottom-color: black
+    border-bottom-color: black
 }
 
 .reveal .controls div.navigate-down,
 .reveal .controls div.navigate-down.enabled
 {
-  border-top-color: black
+    border-top-color: black
 }
 
 .reveal .controls div.navigate-left,
 .reveal .controls div.navigate-left.enabled
 {
-  border-right-color: black
+    border-right-color: black
 }
 
 .reveal .controls div.navigate-right,
 .reveal .controls div.navigate-right.enabled
 {
-  border-left-color: black
+    border-left-color: black
 }
 
 
@@ -125,12 +125,12 @@ body,
 }
 
 @media print {
-  .reveal h1,
-  .reveal h2,
-  .reveal h3,
-  .reveal h4,
-  .reveal h5,
-  .reveal h6 {
-      color: black;
-  }
+    .reveal h1,
+    .reveal h2,
+    .reveal h3,
+    .reveal h4,
+    .reveal h5,
+    .reveal h6 {
+        color: black;
+    }
 }

--- a/css/reveal-override.css
+++ b/css/reveal-override.css
@@ -1,136 +1,72 @@
 @import url(//fonts.googleapis.com/css?family=Cabin:400,700);
 @import url(//fonts.googleapis.com/css?family=Special+Elite:400,700);
 @import url(http://fonts.googleapis.com/css?family=Open+Sans+Condensed:300);
-
-/* Disable background 4px border around images */
-.reveal section img {
+.reveal {
+  font-family: "Open Sans Condensed", sans-serif;
+  font-weight: normal;
+  /* Blow iframe up to full screen size */ }
+  .reveal section img {
+    /* Disable background 4px border around images */
     border: none;
     background: none;
-}
-
-/* Blow image up to full screen size */
-.reveal section img
-{
+    /* Blow image up to full screen size */
     height: auto;
     width: 100%;
     max-width: 80%;
     max-height: 80%;
-    margin: 2%;
-}
-
-/* Blow iframe up to full screen size */
-.reveal iframe
-{
+    margin: 2%; }
+  .reveal iframe {
     height: 90%;
     width: 100%;
-    margin: 2%;
-}
-
-body,
-.reveal {
-    font-family: "Open Sans Condensed", sans-serif;
-    font-weight: normal;
-}
-
-.reveal h1 {
-    font-size: 5em;
-}
-
-.reveal h2 {
-    font-size: 3em;
-}
-
-.reveal h3 {
-    font-size: 1.5em;
-}
-
-.reveal h1,
-.reveal h2,
-.reveal h3,
-.reveal h4,
-.reveal h5,
-.reveal h6 {
+    margin: 2%; }
+  .reveal h1 {
+    font-size: 5em; }
+  .reveal h2 {
+    font-size: 3em; }
+  .reveal h3 {
+    font-size: 1.5em; }
+  .reveal h1, .reveal h2, .reveal h3, .reveal h4, .reveal h5, .reveal h6 {
     font-family: "Cabin", sans-serif;
     font-weight: bold;
     text-transform: uppercase;
     text-stroke: 1px black;
     color: white;
-    text-shadow:
-        3px 3px 0 #000,
-        -1px -1px 0 #000,
-        1px -1px 0 #000,
-        -1px 1px 0 #000,
-        1px 1px 0 #000;
-}
-
-.reveal .progress span {
-    background-color: black
-}
-
-.reveal .controls div.navigate-up,
-.reveal .controls div.navigate-up.enabled
-{
-    border-bottom-color: black
-}
-
-.reveal .controls div.navigate-down,
-.reveal .controls div.navigate-down.enabled
-{
-    border-top-color: black
-}
-
-.reveal .controls div.navigate-left,
-.reveal .controls div.navigate-left.enabled
-{
-    border-right-color: black
-}
-
-.reveal .controls div.navigate-right,
-.reveal .controls div.navigate-right.enabled
-{
-    border-left-color: black
-}
-
-
-.reveal a {
-    font-family: "Special Elite", monospace !important;
-}
-
-.reveal code {
+    text-shadow: 3px 3px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000; }
+  .reveal .progress span {
+    background-color: black; }
+  .reveal .controls div.navigate-up, .reveal .controls div.navigate-up.enabled {
+    border-bottom-color: black; }
+  .reveal .controls div.navigate-down, .reveal .controls div.navigate-down.enabled {
+    border-top-color: black; }
+  .reveal .controls div.navigate-left, .reveal .controls div.navigate-left.enabled {
+    border-right-color: black; }
+  .reveal .controls div.navigate-right, .reveal .controls div.navigate-right.enabled {
+    border-left-color: black; }
+  .reveal a {
+    font-family: "Special Elite", monospace !important; }
+  .reveal code {
     font-family: "Special Elite", monospace !important;
     color: black !important;
     text-shadow: none;
-    text-transform: none;
-}
-
-.reveal pre code {
+    text-transform: none; }
+  .reveal pre code {
     font-family: "Source Code Pro", monospace !important;
     background: inherit !important;
     text-shadow: none;
-    text-transform: none;
-}
-
-.reveal .stamp {
+    text-transform: none; }
+  .reveal .stamp {
     position: absolute;
     color: red !important;
     font-size: 6em !important;
     font-family: "Special Elite" !important;
     transform: rotate(-45deg);
-    position:absolute;
-    left:50%;
-    top:50%;
-    margin-left:-20vw;
-    margin-top:-10vh;
-    text-shadow: none;
-}
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    margin-left: -20vw;
+    margin-top: -10vh;
+    text-shadow: none; }
 
 @media print {
-    .reveal h1,
-    .reveal h2,
-    .reveal h3,
-    .reveal h4,
-    .reveal h5,
-    .reveal h6 {
-        color: black;
-    }
-}
+  .reveal h1, .reveal h2, .reveal h3, .reveal h4, .reveal h5, .reveal h6 {
+    color: black; } }

--- a/css/reveal-override.scss
+++ b/css/reveal-override.scss
@@ -1,0 +1,116 @@
+@import url(//fonts.googleapis.com/css?family=Cabin:400,700);
+@import url(//fonts.googleapis.com/css?family=Special+Elite:400,700);
+@import url(http://fonts.googleapis.com/css?family=Open+Sans+Condensed:300);
+
+.reveal {
+    font-family: "Open Sans Condensed", sans-serif;
+    font-weight: normal;
+
+    section img {
+        /* Disable background 4px border around images */
+        border: none;
+        background: none;
+
+        /* Blow image up to full screen size */
+        height: auto;
+        width: 100%;
+        max-width: 80%;
+        max-height: 80%;
+        margin: 2%;
+    }
+
+    /* Blow iframe up to full screen size */
+    iframe {
+        height: 90%;
+        width: 100%;
+        margin: 2%;
+    }
+
+    h1 {
+        font-size: 5em;
+    }
+
+    h2 {
+        font-size: 3em;
+    }
+
+    h3 {
+        font-size: 1.5em;
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+        font-family: "Cabin", sans-serif;
+        font-weight: bold;
+        text-transform: uppercase;
+        text-stroke: 1px black;
+        color: white;
+        text-shadow:
+            3px 3px 0 #000,
+            -1px -1px 0 #000,
+            1px -1px 0 #000,
+            -1px 1px 0 #000,
+            1px 1px 0 #000;
+    }
+
+    .progress span {
+        background-color: black
+    }
+
+    .controls {
+        div.navigate-up, div.navigate-up.enabled {
+            border-bottom-color: black
+        }
+
+        div.navigate-down, div.navigate-down.enabled {
+            border-top-color: black
+        }
+
+        div.navigate-left, div.navigate-left.enabled {
+            border-right-color: black
+        }
+
+        div.navigate-right, div.navigate-right.enabled {
+            border-left-color: black
+        }
+    }
+
+    a {
+        font-family: "Special Elite", monospace !important;
+    }
+
+    code {
+        font-family: "Special Elite", monospace !important;
+        color: black !important;
+        text-shadow: none;
+        text-transform: none;
+    }
+
+    pre code {
+        font-family: "Source Code Pro", monospace !important;
+        background: inherit !important;
+        text-shadow: none;
+        text-transform: none;
+    }
+
+    .stamp {
+        position: absolute;
+        color: red !important;
+        font-size: 6em !important;
+        font-family: "Special Elite" !important;
+        transform: rotate(-45deg);
+        position:absolute;
+        left:50%;
+        top:50%;
+        margin-left:-20vw;
+        margin-top:-10vh;
+        text-shadow: none;
+    }
+}
+
+@media print {
+    .reveal {
+        h1, h2, h3, h4, h5, h6 {
+            color: black;
+        }
+    }
+}

--- a/index.html
+++ b/index.html
@@ -5,12 +5,12 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-      
+
     <!-- reveal.js CSS theme and local overrides -->
     <link rel="stylesheet" href="reveal.js/css/reveal.css"/>
     <link rel="stylesheet" href="reveal.js/css/theme/default.css" id="theme"/>
     <link rel="stylesheet" href="css/reveal-override.css"/>
-	  
+
     <!-- For syntax highlighting -->
     <link rel="stylesheet" href="reveal.js/lib/css/zenburn.css" />
 
@@ -26,28 +26,28 @@
     <div class="reveal">
       <div class="slides">
         <section>
-	  <div class="qrcode" id="qrcode-talk"/>
-	  <p><a href="https://example.com/link/to/this/talk" target="_blank"
-		id="talk">https://example.com/link/to/this/talk</a></p>
+          <div class="qrcode" id="qrcode-talk"/>
+          <p><a href="https://example.com/link/to/this/talk" target="_blank"
+                id="talk">https://example.com/link/to/this/talk</a></p>
         </section>
-      	<section id="intro"
-		 data-markdown="markdown/intro.md"
-		 data-separator="^\n\n\n"
-		 data-separator-vertical="^\n\n"
-		 data-separator-notes="^Note:">
-	</section>
-	<section id="main"
-		 data-markdown="markdown/main.md"
-		 data-separator="^\n\n\n"
-		 data-separator-vertical="^\n\n"
-		 data-separator-notes="^Note:">
-	</section>
-	<section id="conclusion"
-		 data-markdown="markdown/conclusion.md"
-		 data-separator="^\n\n\n"
-		 data-separator-vertical="^\n\n"
-		 data-separator-notes="^Note:">
-	</section>
+        <section id="intro"
+                 data-markdown="markdown/intro.md"
+                 data-separator="^\n\n\n"
+                 data-separator-vertical="^\n\n"
+                 data-separator-notes="^Note:">
+        </section>
+        <section id="main"
+                 data-markdown="markdown/main.md"
+                 data-separator="^\n\n\n"
+                 data-separator-vertical="^\n\n"
+                 data-separator-notes="^Note:">
+        </section>
+        <section id="conclusion"
+                 data-markdown="markdown/conclusion.md"
+                 data-separator="^\n\n\n"
+                 data-separator-vertical="^\n\n"
+                 data-separator-notes="^Note:">
+        </section>
       </div>
     </div>
 
@@ -62,24 +62,24 @@ for (var i = 0; i < n; i++) {
 
     /* If the link has no href attribute, skip it */
     if (href) {
-	var target_id = "qrcode-" + source.id ;
-	var target = document.getElementById(target_id);
-	/* If the source has no corresponding target element, skip
-	 * it */
-	if (target) {
-	    var qr = new QRCode(target, {
-		colorDark : "#000000",
-		colorLight : "rgba(255,255,255,0)",
-	    });
-	    qr.makeCode(href);
-	}
+        var target_id = "qrcode-" + source.id ;
+        var target = document.getElementById(target_id);
+        /* If the source has no corresponding target element, skip
+         * it */
+        if (target) {
+            var qr = new QRCode(target, {
+                colorDark : "#000000",
+                colorLight : "rgba(255,255,255,0)",
+            });
+            qr.makeCode(href);
+        }
     }
 }
     </script>
 
     <script src="reveal.js/lib/js/head.min.js"></script>
     <script src="reveal.js/js/reveal.js"></script>
-    
+
     <script>
 // Full list of configuration options available here:
 // https://github.com/hakimel/reveal.js#configuration
@@ -97,15 +97,15 @@ Reveal.initialize({
 
     theme: Reveal.getQueryHash().theme, // available themes are in /css/theme
     transition: Reveal.getQueryHash().transition || 'fade', // default/cube/page/concave/zoom/linear/fade/none
-    
+
     // Optional libraries used to extend on reveal.js
     dependencies: [
-	{ src: 'reveal.js/lib/js/classList.js', condition: function() { return !document.body.classList; } },
-	{ src: 'reveal.js/plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
-	{ src: 'reveal.js/plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
-	{ src: 'reveal.js/plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
-	{ src: 'reveal.js/plugin/zoom-js/zoom.js', async: true, condition: function() { return !!document.body.classList; } },
-	{ src: 'reveal.js/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } }
+        { src: 'reveal.js/lib/js/classList.js', condition: function() { return !document.body.classList; } },
+        { src: 'reveal.js/plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
+        { src: 'reveal.js/plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
+        { src: 'reveal.js/plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
+        { src: 'reveal.js/plugin/zoom-js/zoom.js', async: true, condition: function() { return !!document.body.classList; } },
+        { src: 'reveal.js/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } }
     ]
 });
     </script>


### PR DESCRIPTION
**PLEASE NOTE**: this PR is dependent on #9 so should not be merged until a) #9 has been merged and b) this PR has been rebased on the new `master`.  Currently it contains the commits from #9.

SASS gives us much cleaner CSS than CSS.  The `.css` version can be auto-generated via

```
sass --watch --sourcemap css/reveal-override.scss
```
